### PR TITLE
Bugfix thumbnails broken

### DIFF
--- a/FantasyModuleParser/Exporters/FantasyGroundsExporter.cs
+++ b/FantasyModuleParser/Exporters/FantasyGroundsExporter.cs
@@ -1133,14 +1133,7 @@ namespace FantasyModuleParser.Exporters
 			xmlWriter.WriteString("reference_colindex");
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteStartElement("recordname");
-			if (moduleModel.IsLockedRecords)
-			{
-				xmlWriter.WriteString(listId + "@" + moduleModel.Name);
-			}				
-			else
-			{
-				xmlWriter.WriteString(listId);
-			}				
+			xmlWriter.WriteString(listId);				
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteEndElement();
 			xmlWriter.WriteStartElement("name");


### PR DESCRIPTION
Fixed an issue where Thumbnails would be saved to wrong location causing an error when creating module.

Fixed a secondary issue where NPC List by Alphabet, CR, etc. wouldn't work as the Module Name was duplicated.