### PR TITLE
SubDirectories now created at initial startup

### DIFF
--- a/FantasyModuleParser/App.xaml.cs
+++ b/FantasyModuleParser/App.xaml.cs
@@ -48,14 +48,17 @@ namespace FantasyModuleParser
         private static readonly ILog log = LogManager.GetLogger(typeof(App));
         protected override void OnStartup(StartupEventArgs e) 
         {
+            SettingsService settingService = new SettingsService();
+            SettingsModel settingsModel = settingService.Load();
             #region Log4Net Info
             //log4net.Config.XmlConfigurator.Configure(Log4NetXmlSetup());
-            Log4NetXmlSetup();
+            Directory.CreateDirectory(settingsModel.MainFolderLocation);
+            Directory.CreateDirectory(Path.Combine(settingsModel.MainFolderLocation, "logs"));
+            Log4NetXmlSetup(Path.Combine(settingsModel.MainFolderLocation, "logs"));
             RollingFileAppender fileAppender = LogManager.GetRepository()
                 .GetAppenders().First(appender => appender is RollingFileAppender) as RollingFileAppender;
             #endregion
-            SettingsService settingService = new SettingsService();
-            SettingsModel settingsModel = settingService.Load();
+            
             #region Log4Net Info
             string logFolderPath = settingsModel.LogFolderLocation;
 
@@ -74,9 +77,11 @@ namespace FantasyModuleParser
             #endregion
         }
 
-        private void Log4NetXmlSetup()
+        private void Log4NetXmlSetup(string @logFolderPath)
         {
-            const string xmlData = @" <log4net>
+            string logFilePath = Path.Combine(logFolderPath, "fantasyModuleParser.log");
+
+            string xmlData = string.Format(@" <log4net>
   <root>
     <level value=""DEBUG"" />
     <appender-ref ref= ""console"" />
@@ -89,7 +94,7 @@ namespace FantasyModuleParser
        </appender >
        <appender name = ""file"" type = ""log4net.Appender.RollingFileAppender"" >
             <file type = ""log4net.Util.PatternString""
-    value = ""%envFolderPath{MainFolderLocation}\\logs\\fantasyModuleParser.log"" />
+    value = ""{0}"" />
     <appendToFile value = ""true"" />
      <rollingStyle value = ""Size"" />
       <maxSizeRollBackups value = ""5"" />
@@ -99,7 +104,7 @@ namespace FantasyModuleParser
             <conversionPattern value = ""%date [%thread] %level %logger - %message%newline"" />
            </layout >
                 </appender >
-       </log4net > ";
+       </log4net > ", logFilePath);
 
             //return new MemoryStream(ASCIIEncoding.Default.GetBytes(xmlData));
 

--- a/FantasyModuleParser/Main/Services/SettingsService.cs
+++ b/FantasyModuleParser/Main/Services/SettingsService.cs
@@ -43,15 +43,15 @@ namespace FantasyModuleParser.Main.Services
         }
         public static SettingsModel Load(string filePath)
         {
+            SettingsModel settingsModel = null;
             if (File.Exists(filePath))
             {
                 string jsonData = File.ReadAllText(@filePath);
-                SettingsModel settingsModel = JsonConvert.DeserializeObject<SettingsModel>(jsonData);
-                return settingsModel;
+               settingsModel = JsonConvert.DeserializeObject<SettingsModel>(jsonData);
             }
             else
             {
-                SettingsModel settingsModel = new SettingsModel();
+                settingsModel = new SettingsModel();
                 settingsModel.MainFolderLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FMP");
                 settingsModel.ProjectFolderLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FMP", "Projects");
                 settingsModel.NPCFolderLocation = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "FMP", "NPCs");
@@ -66,8 +66,29 @@ namespace FantasyModuleParser.Main.Services
                 settingsModel.DefaultGUISelection = "None";
                 settingsModel.LoadLastProject = false;
                 settingsModel.LastProject = null;
-                return settingsModel;
             }
+
+            _createDirectoryStructure(settingsModel);
+
+            return settingsModel;
+        }
+
+        /// <summary>
+        /// Based on the Settings Model object, creates a directory (or attempts it) for every module folder location
+        /// defined.
+        /// </summary>
+        private static void _createDirectoryStructure(SettingsModel settingsModel)
+        {
+            Directory.CreateDirectory(settingsModel.MainFolderLocation);
+            Directory.CreateDirectory(settingsModel.ProjectFolderLocation );
+            Directory.CreateDirectory(settingsModel.NPCFolderLocation );
+            Directory.CreateDirectory(settingsModel.SpellFolderLocation );
+            Directory.CreateDirectory(settingsModel.EquipmentFolderLocation );
+            Directory.CreateDirectory(settingsModel.ArtifactFolderLocation );
+            Directory.CreateDirectory(settingsModel.TableFolderLocation );
+            Directory.CreateDirectory(settingsModel.ParcelFolderLocation );
+            Directory.CreateDirectory(settingsModel.FGModuleFolderLocation );
+            Directory.CreateDirectory(settingsModel.FGCampaignFolderLocation);
         }
 
         public void ChangeLogLevel()


### PR DESCRIPTION
Whenever the SettingsService.Load() method is called (which is fairly often), any FMP subdirectories are now created.  This addresses a problem a few folks had when trying to create a module, and the Projects folder wasn't setup correctly.